### PR TITLE
feat(base): add opt-in StatefulSet support with per-pod volumeClaimTemplates

### DIFF
--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: 0.1.77
+appVersion: 0.1.78
 description: A Base Helm chart for Kubernetes - ServiceMonitor release-label, port-name + honorLabels support
 icon: https://media.licdn.com/dms/image/C4E0BAQEdK6tkXfbtXQ/company-logo_200_200/0/1674118[…]47483647&v=beta&t=66-Xh3XKEy8l4jC5BCzb-73JqBDxRZPWACNt9KRiL4M
 name: base
 type: application
-version: 0.1.77
+version: 0.1.78

--- a/charts/base/templates/deployment.yaml
+++ b/charts/base/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ .Values.workloadKind | default "Deployment" }}
 metadata:
   name: {{ include "base.fullname" . }}
   labels:
@@ -23,6 +23,9 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if eq (.Values.workloadKind | default "Deployment") "StatefulSet" }}
+  serviceName: {{ .Values.serviceName | default (include "base.fullname" .) }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "base.selectorLabels" . | nindent 6 }}
@@ -31,7 +34,7 @@ spec:
       {{ $value.name }}: {{ $value.value | quote}}
       {{- end }}
       {{- end }}
-  {{- if .Values.strategy }}
+  {{- if and .Values.strategy (ne (.Values.workloadKind | default "Deployment") "StatefulSet") }}
   strategy:
     {{- toYaml .Values.strategy | nindent 12 }}
   {{- end }}
@@ -340,3 +343,19 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if and (eq (.Values.workloadKind | default "Deployment") "StatefulSet") .Values.volumeClaimTemplates }}
+  volumeClaimTemplates:
+    {{- range .Values.volumeClaimTemplates }}
+    - metadata:
+        name: {{ .name }}
+      spec:
+        accessModes:
+          {{- toYaml .accessModes | nindent 10 }}
+        {{- if .storageClassName }}
+        storageClassName: {{ .storageClassName }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .size }}
+    {{- end }}
+  {{- end }}

--- a/charts/base/templates/hpa.yaml
+++ b/charts/base/templates/hpa.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.workloadKind | default "Deployment" }}
     name: {{ include "base.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -4,6 +4,23 @@
 
 replicaCount: 1
 
+# Set to "StatefulSet" to render a StatefulSet instead of a Deployment — needed
+# when replicas each require their own persistent volume (see volumeClaimTemplates
+# below). Deployment (default) is unaffected by any of these StatefulSet-only values.
+workloadKind: Deployment
+
+# Only used when workloadKind: StatefulSet. Defaults to the release fullname.
+serviceName: ""
+
+# Only used when workloadKind: StatefulSet. Each entry provisions one PVC per
+# replica pod (name must match a volumeMount name in .Values.volumeMounts).
+volumeClaimTemplates: []
+# - name: data
+#   accessModes:
+#     - ReadWriteOnce
+#   storageClassName: do-block-storage
+#   size: 1Gi
+
 image:
   repository: nginx
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- Adds `workloadKind: StatefulSet` (default remains `Deployment`, fully backward compatible) plus `volumeClaimTemplates` and `serviceName` values to the shared `base` chart.
- `hpa.yaml`'s `scaleTargetRef.kind` now follows `workloadKind`. `strategy` is only rendered in Deployment mode (StatefulSet doesn't support that field).
- Bumps chart to `0.1.77`.

Needed so `doc2-api/api-flower` can run 2 replicas with an independent persistent volume per pod — Flower's `--persistent=True` state file uses Python's `shelve` module, which isn't safe for concurrent multi-process writes, and DO block storage is ReadWriteOnce only, so a single shared PVC across replicas isn't viable.

DEVO-70

## Test plan
- [x] `helm lint` clean in both default (Deployment) and StatefulSet mode
- [x] `helm template` with default values — confirmed `kind: Deployment` unchanged
- [x] `helm template` with `workloadKind: StatefulSet` + `volumeClaimTemplates` + `volumeMounts` — confirmed `kind: StatefulSet`, `serviceName`, per-pod PVC template, no `strategy` field
- [x] All 9 existing `test-values/*.yaml` regression fixtures still render clean
- [ ] Merge + confirm chart publishes to the index (`update-index.yml`) before the dependent DevOps PR is merged